### PR TITLE
Clean up commented out callback_url, seemingly unnecessary query_string

### DIFF
--- a/lib/omniauth-notion.rb
+++ b/lib/omniauth-notion.rb
@@ -39,9 +39,7 @@ module OmniAuth
       end
 
       extra do
-        {
-          'raw_info' => raw_info
-        }
+        { 'raw_info' => raw_info }
       end
 
       # The Notion API requires HTTP Basic Authentication when exchanging the
@@ -69,32 +67,6 @@ module OmniAuth
 
       def callback_url
         full_host + script_name + callback_path
-      end
-
-      # def callback_url
-      #   if @authorization_code_from_signed_request
-      #     ''
-      #   else
-      #     options[:callback_url] || super
-      #   end
-      # end
-
-      # def callback_url
-      #   # If redirect_uri is configured in token_params, use that
-      #   # value.
-      #   token_params.to_hash(symbolize_keys: true)[:redirect_uri] || super
-      # end
-
-      def query_string
-        # This method is called by callback_url, only if redirect_uri
-        # is omitted in token_params.
-        if request.params['code']
-          # If this is a callback, ignore query parameters added by
-          # the provider.
-          ''
-        else
-          super
-        end
       end
     end
   end


### PR DESCRIPTION
Cleanup based on discussion between @JeremiahChurch and @aguynamedben here: https://github.com/JeremiahChurch/omniauth-notion/pull/2#issuecomment-845553732

@JeremiahChurch I think we'll switch back to using this gem directly. We're seeing all the same stuff working that you are, so we shouldn't need any customizations. If we make any changes we'll contribute them back. Weeeeee FOSS.