### PR TITLE
Update auth params to install at the user level

### DIFF
--- a/lib/omniauth-notion.rb
+++ b/lib/omniauth-notion.rb
@@ -22,6 +22,10 @@ module OmniAuth
           },
         }
 
+      option :authorize_params, {
+        owner: 'user',
+      }
+
       # These are called after authentication has succeeded. If
       # possible, you should try to set the UID without making
       # additional calls (if the user id is returned with the token
@@ -32,8 +36,10 @@ module OmniAuth
       # https://developers.notion.com/docs/authorization#exchanging-the-grant-for-an-access-token
       info do
         {
+          workspace_id: raw_info['workspace_id'],
           workspace_name: raw_info['workspace_name'],
           workspace_icon: raw_info['workspace_icon'],
+          owner: raw_info['owner'],
           bot_id: raw_info['bot_id']
         }
       end

--- a/lib/omniauth-notion/version.rb
+++ b/lib/omniauth-notion/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module Notion
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
Notion made an [update to their API](https://developers.notion.com/docs/authorization#prompting-users-to-add-an-integration) effective September 21, 2021 that moves to install integrations at the user level instead of the workplace admin level. I'm not sure if they'll 500 a request that is missing the URL parameter but this updates the authorize request to provide it.

With this change to user-scoped integration installs, the API now returns the user as a part of the owner object. This commit exposes that in the info object vs having to traverse into `raw_info`.

I also took the liberty of bumping the gem version, but feel free to request I remove that if you wanna run that as a separate PR/commit.