### PR TITLE
Update omniauth requierements to > 2

### DIFF
--- a/omniauth-notion.gemspec
+++ b/omniauth-notion.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'omniauth', '~> 1.0'
+  gem.add_dependency 'omniauth', '~> 2.0.0'
 end


### PR DESCRIPTION
Version 1 of omniauth has a severe security vulnerability addressed in version 2: https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284